### PR TITLE
Add category pattern configuration

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,42 @@
+{
+  "audio": {
+    "filePatterns": ["audio"],
+    "rootTagPatterns": ["CAmbient", "Audio"]
+  },
+  "content": {
+    "filePatterns": ["content"],
+    "rootTagPatterns": ["Content"]
+  },
+  "mission": {
+    "filePatterns": ["mission", "heist"],
+    "rootTagPatterns": ["Mission"]
+  },
+  "ped": {
+    "filePatterns": ["ped"],
+    "rootTagPatterns": ["CPed"]
+  },
+  "props": {
+    "filePatterns": ["_props"],
+    "rootTagPatterns": ["CZonedAssets", "Props"]
+  },
+  "shop": {
+    "filePatterns": ["_shop"],
+    "rootTagPatterns": ["Shop"]
+  },
+  "trigger": {
+    "filePatterns": ["trigger"],
+    "rootTagPatterns": ["Trigger", "ControlInput"]
+  },
+  "vehicle": {
+    "filePatterns": ["vehicle", "car"],
+    "rootTagPatterns": ["CVehicle", "Vehicle"]
+  },
+  "weapon": {
+    "filePatterns": ["^weapon"],
+    "rootTagPatterns": ["CWeapon", "Weapon"]
+  },
+  "misc": {
+    "filePatterns": [],
+    "rootTagPatterns": []
+  }
+}


### PR DESCRIPTION
## Summary
- add categories.json with regex-based rules for classifying meta files by filename and root XML tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afc9857d60832d8244788a261197bd